### PR TITLE
Prevent children rendering for collapsed nodes

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -30,7 +30,6 @@ var Node = React.createClass({
 
     if(index.children && index.children.length) {
       var childrenStyles = {};
-      if(index.node.collapsed) childrenStyles.display = 'none';
       childrenStyles['paddingLeft'] = this.props.paddingLeft + 'px';
 
       return (
@@ -71,7 +70,7 @@ var Node = React.createClass({
           {this.renderCollapse()}
           {tree.renderNode(node)}
         </div>
-        {this.renderChildren()}
+        {node.collapsed ? null : this.renderChildren()}
       </div>
     );
   },


### PR DESCRIPTION
The UI is sluggish for huge trees - even if a node is collapsed its children are rendered and hidden via CSS properties. Preventing them to render greatly improves responsiveness.
