### PR TITLE
Don't notify when dragging does not changed the tree

### DIFF
--- a/lib/react-ui-tree.js
+++ b/lib/react-ui-tree.js
@@ -106,6 +106,7 @@ module.exports = React.createClass({
     this._offsetX = e.clientX;
     this._offsetY = e.clientY;
     this._start = true;
+    this._dragChanged = false;
 
     window.addEventListener('mousemove', this.drag);
     window.addEventListener('mouseup', this.dragEnd);
@@ -189,6 +190,10 @@ module.exports = React.createClass({
       dragging.id = newIndex.id;
     }
 
+    if(newIndex) {
+      this._dragChanged = true;
+    }
+
     this.setState({
       tree: tree,
       dragging: dragging
@@ -213,7 +218,7 @@ module.exports = React.createClass({
 
   change(tree) {
     this._updated = true;
-    if(this.props.onChange) this.props.onChange(tree.obj);
+    if(this.props.onChange && this._dragChanged) this.props.onChange(tree.obj);
   },
 
   toggleCollapse(nodeId) {


### PR DESCRIPTION
When you click a node, you will receive a handleChange notification, which doesn't need.
So, this pull request is a fix of that.