### PR TITLE
Add freeze prop to stop dragging events

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm install react-ui-tree --save
 <Tree
   paddingLeft={20}              // left padding for children nodes in pixels
   tree={this.state.tree}        // tree object
+  freeze={false}                // set it to true to stop dragging events
   onChange={this.handleChange}  // onChange(tree) tree object changed
   renderNode={this.renderNode}  // renderNode(node) return react element
 />

--- a/lib/react-ui-tree.js
+++ b/lib/react-ui-tree.js
@@ -8,6 +8,7 @@ module.exports = React.createClass({
   propTypes: {
     tree: React.PropTypes.object.isRequired,
     paddingLeft: React.PropTypes.number,
+    freeze: React.PropTypes.bool,
     renderNode: React.PropTypes.func.isRequired
   },
 
@@ -84,7 +85,7 @@ module.exports = React.createClass({
           index={tree.getIndex(1)}
           key={1}
           paddingLeft={this.props.paddingLeft}
-          onDragStart={this.dragStart}
+          onDragStart={this.props.freeze ? null : this.dragStart}
           onCollapse={this.toggleCollapse}
           dragging={dragging && dragging.id}
         />


### PR DESCRIPTION
I couldn't prevent the tree from being modified in the `onChange` event so this PR just adds a new prop to make it easy to stop dragging events. I didn't name the prop `editable` in order not to break compatibility with current code.

If you think this is a good idea, please feel free to change the prop name or modify the code in any other way.

Thanks a lot for this useful React component!