### PR TITLE
Pass node through to onChange method.

### DIFF
--- a/dist/react-ui-tree.js
+++ b/dist/react-ui-tree.js
@@ -209,9 +209,9 @@ module.exports = React.createClass({
     window.removeEventListener('mousemove', this.drag);
     window.removeEventListener('mouseup', this.dragEnd);
   },
-  change: function change(tree) {
+  change: function change(tree, node) {
     this._updated = true;
-    if (this.props.onChange) this.props.onChange(tree.obj);
+    if (this.props.onChange) this.props.onChange(tree.obj, node);
   },
   toggleCollapse: function toggleCollapse(nodeId) {
     var tree = this.state.tree;
@@ -224,6 +224,6 @@ module.exports = React.createClass({
       tree: tree
     });
 
-    this.change(tree);
+    this.change(tree, node);
   }
 });


### PR DESCRIPTION
This will allow more efficient handling to state change without having to search through the whole tree to see what has changed.