### PR TITLE
collapse hook

### DIFF
--- a/lib/react-ui-tree.js
+++ b/lib/react-ui-tree.js
@@ -231,6 +231,7 @@ class UITree extends Component {
     const node = index.node;
     node.collapsed = !node.collapsed;
     tree.updateNodesPosition();
+    tree.changeNodeCollapsed(node);
 
     this.setState({
       tree: tree


### PR DESCRIPTION
changeNodeCollapsed  was introduced in c5823fd004fad54950c7054a61abfb481a0305b7 but isn't used. I'm guessing that it is a callback to be used when there is a collapse event.